### PR TITLE
Fix julia binary tarball links.

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -64,7 +64,7 @@ fi
 
 if [ $target = "x86_64-w64-mingw32" ]; then
 cd $WORKSPACE/srcdir
-wget "http://mlg.eng.cam.ac.uk/hong/julia-1.0.0-win64.tar.gz"
+wget "http://mlg.eng.cam.ac.uk/hong/julia/julia-1.0.0-win64.tar.gz"
 tar xzvf julia-1.0.0-win64.tar.gz 
 rm *.tar.gz
 mv julia* julia
@@ -80,7 +80,7 @@ fi
 
 if [ $target = "i686-w64-mingw32" ]; then
 cd $WORKSPACE/srcdir
-wget "http://mlg.eng.cam.ac.uk/hong/julia-1.0.0-win32.tar.gz"
+wget "http://mlg.eng.cam.ac.uk/hong/julia/julia-1.0.0-win32.tar.gz"
 tar xzvf julia-1.0.0-win32.tar.gz 
 rm *.tar.gz
 mv julia* julia
@@ -96,7 +96,7 @@ fi
 
 if [ $target = "x86_64-apple-darwin14" ]; then
 cd $WORKSPACE/srcdir
-wget "http://mlg.eng.cam.ac.uk/hong/julia-1.0.0-mac64.tar.gz"
+wget "http://mlg.eng.cam.ac.uk/hong/julia/julia-1.0.0-mac64.tar.gz"
 tar xzvf julia-1.0.0-mac64.tar.gz 
 rm *.tar.gz
 mv julia* julia


### PR DESCRIPTION
This PR prepares `Libtask` for Julia 1.1.0, which removes a field `parent` from task types (see https://github.com/JuliaLang/julia/pull/29483).